### PR TITLE
规范 Docker 部署环境变量的 JSON 格式

### DIFF
--- a/docs/start/build.md
+++ b/docs/start/build.md
@@ -15,7 +15,7 @@ docker run -d \
     -v $(pwd)/db:/app/db \
     -p 8000:8000 \
     -e TIMEOUT=600 \
-    -e DOMAINS="['yourdomain.com','www.yourdomain.com']" \
+    -e DOMAINS="[\"yourdomain.com\",\"www.yourdomain.com\"]" \
     --name="qexo" \
     abudulin/qexo:latest
 ```

--- a/docs/start/build.md
+++ b/docs/start/build.md
@@ -38,7 +38,7 @@ services:
       WORKERS: 4
       THREADS: 4
       TIMEOUT: 600
-      DOMAINS: "['yourdomain.com','www.yourdomain.com']"
+      DOMAINS: "[\"yourdomain.com\",\"www.yourdomain.com\"]"
     volumes:
       - ./db:/app/db
 ```


### PR DESCRIPTION
使用单引号会让 Python 无法解析 JSON 而报错无法运行，导致 8000 端口拒绝连接。

这会误导很多新手，因为我在知道是这个原因之前还认为我不会配置。请原谅文档评论中的那些问题，因为他们可能也没想到这些。