### PR TITLE
docs: 修正 GitHub Token 权限说明（Contents/Workflow 设为 Read and write）

### DIFF
--- a/docs/configs/provider.md
+++ b/docs/configs/provider.md
@@ -47,7 +47,8 @@ master
 ### Github 密钥
 
 于 [Github 设置](https://github.com/settings/tokens) 生成的 Token (建议使用 Classical)
-需要 Repo & Workflow 下的权限 *不建议给出所有权限*
+需要 Contents 和 Workflow 两项权限，且访问权限应设置为 Read and write，不建议给出所有权限
+![GitHub Token 权限设置](https://s3.bmp.ovh/2026/07/13/ao0KsmAq.png)
 
 ```
 wrq_P8sYPlYA9fjMlOPEYSKA84xxxxxxxxxxxxxx

--- a/docs/en/configs/provider.md
+++ b/docs/en/configs/provider.md
@@ -44,7 +44,8 @@ master
 ### Github Token
 
 Token generated at [Github Settings](https://github.com/settings/tokens) (Classical recommended)
-Requires permissions under Repo & Workflow *do not provide all permissions*
+Requires Contents and Workflow permissions, both set to Read and write (do not provide all permissions)
+![GitHub Token permission settings](https://s3.bmp.ovh/2026/07/13/ao0KsmAq.png)
 
 ```
 wrq_P8sYPlYA9fjMlOPEYSKA84xxxxxxxxxxxxxx


### PR DESCRIPTION
## 改动说明

- 权限分类由 `Repo & Workflow` 改为 **Contents 和 Workflow**
- 明确 Contents / Workflow 访问权限设为 **Read and write**
- 保留「不建议给出所有权限」提醒
- 在描述下方补充权限设置截图

仅涉及文档说明修正，无代码变更。